### PR TITLE
`app-ads.txt` を追加

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-1868308870359139, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## 概要
[アプリ用のapp-ads.txtファイルを設定する](https://support.google.com/admob/answer/9363762?hl=en) に従って [app-ads.txt](./app-ads.txt) を配置。

[acannie.github.io/app-ads.txt](https://acannie.github.io/app-ads.txt) ←ここに配置される予定