### PR TITLE
.gitignoreをNext.js用に更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,11 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+# Created by https://www.toptal.com/developers/gitignore/api/nextjs
+# Edit at https://www.toptal.com/developers/gitignore?templates=nextjs
 
+### NextJS ###
 # dependencies
 /node_modules
 /.pnp
-.pnp.*
-.yarn/*
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/versions
+.pnp.js
 
 # testing
 /coverage
@@ -30,8 +27,8 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-.env*
+# local env files
+.env*.local
 
 # vercel
 .vercel
@@ -39,3 +36,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# End of https://www.toptal.com/developers/gitignore/api/nextjs


### PR DESCRIPTION
## 概要

## 目的

## 参考文献
- [gitignore.io](https://www.toptal.com/developers/gitignore/api/nextjs)

## 結果
N/A
